### PR TITLE
Create private-clusters.md

### DIFF
--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -66,8 +66,8 @@ Where `--enable-private-cluster` is a mandatory flag for a private cluster.
 
 The following parameters can be leveraged to configure Private DNS Zone.
 
-- "System", which is also the default value. If the --private-dns-zone argument is omitted, AKS will create a Private DNS Zone in the Node Resource Group.
-- "None", defaults to public DNS which means AKS will not create a Private DNS Zone (PREVIEW).  
+- "system", which is also the default value. If the --private-dns-zone argument is omitted, AKS will create a Private DNS Zone in the Node Resource Group.
+- "none", defaults to public DNS which means AKS will not create a Private DNS Zone (PREVIEW).  
 - "CUSTOM_PRIVATE_DNS_ZONE_RESOURCE_ID", which requires you to create a Private DNS Zone in this format for azure global cloud: `privatelink.<region>.azmk8s.io`. You will need the Resource Id of that Private DNS Zone going forward.  Additionally, you will need a user assigned identity or service principal with at least the `private dns zone contributor`  and `vnet contributor` roles.
   - If the Private DNS Zone is in a different subscription than the AKS cluster, you need to register Microsoft.ContainerServices in both the subscriptions.
   - "fqdn-subdomain" can be utilized with "CUSTOM_PRIVATE_DNS_ZONE_RESOURCE_ID" only to provide subdomain capabilities to `privatelink.<region>.azmk8s.io`


### PR DESCRIPTION
The documentation was wrong and use 'S(capital)ystem' while REST API allowed value is 's(not capital)ystem' or 'none'  Thus, if you perform change on pvt dns zone, cluster will be recreate not updated. Thus, will cause dowtime. 
https://docs.microsoft.com/en-us/rest/api/aks/managed-clusters/get#managedclusterapiserveraccessprofile
https://docs.microsoft.com/en-us/rest/api/aks/managed-clusters/get#managedclusterautoupgradeprofile

Updated the following lines. 
- "system", which is also the default value. If the --private-dns-zone argument is omitted, AKS will create a Private DNS Zone in the Node Resource Group.
- "none", defaults to public DNS which means AKS will not create a Private DNS Zone (PREVIEW).